### PR TITLE
Build universal native library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,9 @@
                                 <clearDefaultOptions>true</clearDefaultOptions>
                                 <options>
                                     <option>-arch</option>
-                                    <option>${nar.arch}</option>
+                                    <option>x86_64</option>
+                                    <option>-arch</option>
+                                    <opiton>arm64</option>
                                     <option>-mmacosx-version-min=10.9</option>
                                     <option>-fobjc-exceptions</option>
                                     <option>-std=c99</option>
@@ -269,6 +271,10 @@
                             </c>
                             <linker>
                                 <options>
+                                    <option>-arch</option>
+                                    <option>x86_64</option>
+                                    <option>-arch</option>
+                                    <opiton>arm64</option>
                                     <option>-framework</option>
                                     <option>Cocoa</option>
                                     <option>-mmacosx-version-min=10.9</option>


### PR DESCRIPTION
Recent gcc on macOS support universal binary.
It is built when `-arch x86_64 -arch arm64` option to compiler and linker.